### PR TITLE
Completed working endpoint for public paste searches.

### DIFF
--- a/src/main/java/com/urcodebin/api/controllers/CodePasteController.java
+++ b/src/main/java/com/urcodebin/api/controllers/CodePasteController.java
@@ -1,12 +1,14 @@
 package com.urcodebin.api.controllers;
 
 import com.urcodebin.api.entities.CodePaste;
+import com.urcodebin.api.enums.PasteSyntax;
 import com.urcodebin.api.error.exception.PasteNotFoundException;
 import com.urcodebin.api.services.interfaces.CodePasteService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -35,9 +37,25 @@ public class CodePasteController {
     }
 
     @GetMapping(path = "/public")
-    public List<CodePaste> getListOfPublicPastesWith(@RequestParam("paste_title") String pasteTitle,
-                                                     @RequestParam("paste_syntax") String pasteSyntax,
-                                                     @RequestParam("limit") int limit) {
-        return null;
+    public List<CodePaste> getListOfPublicPastesWith(
+                @RequestParam(value = "paste_title", defaultValue = "") String pasteTitle,
+                @RequestParam(value = "paste_syntax", required = false) String pasteSyntax,
+                @RequestParam(value = "limit", defaultValue = "5") int limit) {
+        if(limit > 20 || limit < 1)
+            throw new IllegalArgumentException("limit number must be between 1 and 20.");
+
+        if(pasteSyntax == null)
+            return codePasteService.findListOfCodePastesBy(pasteTitle, limit);
+
+        PasteSyntax pasteSyntaxToSearch = createPasteSyntaxFromString(pasteSyntax);
+        return codePasteService.findListOfCodePastesBy(pasteTitle, pasteSyntaxToSearch, limit);
+    }
+
+    private PasteSyntax createPasteSyntaxFromString(String pasteSyntax) {
+        try {
+            return PasteSyntax.valueOf(pasteSyntax);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("paste_syntax parameter is not any of the given options.");
+        }
     }
 }

--- a/src/main/java/com/urcodebin/api/repository/CodePasteRepository.java
+++ b/src/main/java/com/urcodebin/api/repository/CodePasteRepository.java
@@ -11,16 +11,14 @@ import java.util.UUID;
 
 public interface CodePasteRepository extends JpaRepository<CodePaste, UUID> {
 
-    @Query(value = "SELECT c \n" +
-            "FROM \n" +
+    @Query(value = "FROM \n" +
             "   #{#entityName} c \n" +
             "WHERE \n" +
             "   c.pasteTitle LIKE %?1% AND \n" +
             "   c.pasteVisibility = 'PUBLIC'")
     List<CodePaste> findCodePastesContainTitle(String pasteTitle, Pageable pageLimit);
 
-    @Query(value = "SELECT c \n" +
-            "FROM \n" +
+    @Query(value = "FROM \n" +
             "   #{#entityName} c \n" +
             "WHERE \n" +
             "   c.pasteTitle LIKE %?1% AND \n" +

--- a/src/main/java/com/urcodebin/api/repository/CodePasteRepository.java
+++ b/src/main/java/com/urcodebin/api/repository/CodePasteRepository.java
@@ -1,9 +1,30 @@
 package com.urcodebin.api.repository;
 
 import com.urcodebin.api.entities.CodePaste;
+import com.urcodebin.api.enums.PasteSyntax;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface CodePasteRepository extends JpaRepository<CodePaste, UUID> {
+
+    @Query(value = "SELECT c \n" +
+            "FROM \n" +
+            "   #{#entityName} c \n" +
+            "WHERE \n" +
+            "   c.pasteTitle LIKE %?1% AND \n" +
+            "   c.pasteVisibility = 'PUBLIC'")
+    List<CodePaste> findCodePastesContainTitle(String pasteTitle, Pageable pageLimit);
+
+    @Query(value = "SELECT c \n" +
+            "FROM \n" +
+            "   #{#entityName} c \n" +
+            "WHERE \n" +
+            "   c.pasteTitle LIKE %?1% AND \n" +
+            "   c.pasteVisibility = 'PUBLIC' AND \n" +
+            "   c.pasteSyntax = ?2")
+    List<CodePaste> findCodePastesContaining(String pasteTitle, PasteSyntax pasteSyntax, Pageable pageLimit);
 }

--- a/src/main/java/com/urcodebin/api/services/CodePasteServiceImpl.java
+++ b/src/main/java/com/urcodebin/api/services/CodePasteServiceImpl.java
@@ -1,14 +1,18 @@
 package com.urcodebin.api.services;
 
 import com.urcodebin.api.entities.CodePaste;
-import com.urcodebin.api.error.exception.PasteNotFoundException;
+import com.urcodebin.api.enums.PasteSyntax;
+import com.urcodebin.api.enums.PasteVisibility;
 import com.urcodebin.api.repository.CodePasteRepository;
 import com.urcodebin.api.services.interfaces.CodePasteService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -29,5 +33,17 @@ public class CodePasteServiceImpl implements CodePasteService {
         if(!foundCodePaste.isPresent())
             LOGGER.warn("No CodePaste was found using ID: {}", id);
         return foundCodePaste;
+    }
+
+    @Override
+    public List<CodePaste> findListOfCodePastesBy(String pasteTitle, PasteSyntax pasteSyntax, int limit) {
+        Pageable pageLimit = PageRequest.of(0, limit);
+        return codePasteRepository.findCodePastesContaining(pasteTitle, pasteSyntax, pageLimit);
+    }
+
+    @Override
+    public List<CodePaste> findListOfCodePastesBy(String pasteTitle, int limit) {
+        Pageable pageLimit = PageRequest.of(0, limit);
+        return codePasteRepository.findCodePastesContainTitle(pasteTitle, pageLimit);
     }
 }

--- a/src/main/java/com/urcodebin/api/services/interfaces/CodePasteService.java
+++ b/src/main/java/com/urcodebin/api/services/interfaces/CodePasteService.java
@@ -1,11 +1,17 @@
 package com.urcodebin.api.services.interfaces;
 
 import com.urcodebin.api.entities.CodePaste;
+import com.urcodebin.api.enums.PasteSyntax;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface CodePasteService {
 
     Optional<CodePaste> findByCodePasteId(UUID id);
+
+    List<CodePaste> findListOfCodePastesBy(String pasteTitle, PasteSyntax pasteSyntax, int limit);
+
+    List<CodePaste> findListOfCodePastesBy(String pasteTitle, int limit);
 }


### PR DESCRIPTION
`/api/paste/public` endpoint is exposed to allow for general searches of public pastes that are available. There are 3 optional parameters that can be used to search.

**paste_title** - Search for public pastes with a title that contains this. (_Default:_ " ")
**paste_syntax** - Search for public pastes that use a specific syntax. (_Default:_ "ALL")
**limit** - Limit the number of results received. _0 < limit < 21_ (_Default:_ "5")