### PR TITLE
Feature/Add JWT Security And Limit Endpoint Accessibility Accordingly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,12 @@
 			<artifactId>modelmapper</artifactId>
 			<version>2.3.5</version>
 		</dependency>
-    </dependencies>
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>3.12.0</version>
+		</dependency>
+	</dependencies>
 
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
 			<artifactId>java-jwt</artifactId>
 			<version>3.12.0</version>
 		</dependency>
+		<dependency>
+			<groupId>com.github.ulisesbocchio</groupId>
+			<artifactId>jasypt-spring-boot</artifactId>
+			<version>3.0.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/urcodebin/api/UrCodebinApiApplication.java
+++ b/src/main/java/com/urcodebin/api/UrCodebinApiApplication.java
@@ -3,13 +3,16 @@ package com.urcodebin.api;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.modelmapper.ModelMapper;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
 @EnableEncryptableProperties
+@EnableAutoConfiguration(exclude = {ErrorMvcAutoConfiguration.class})
 public class UrCodebinApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/urcodebin/api/UrCodebinApiApplication.java
+++ b/src/main/java/com/urcodebin/api/UrCodebinApiApplication.java
@@ -1,14 +1,15 @@
 package com.urcodebin.api;
 
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.modelmapper.ModelMapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
+@EnableEncryptableProperties
 public class UrCodebinApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/urcodebin/api/UrCodebinApiApplication.java
+++ b/src/main/java/com/urcodebin/api/UrCodebinApiApplication.java
@@ -5,6 +5,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
 public class UrCodebinApiApplication {
@@ -16,5 +18,10 @@ public class UrCodebinApiApplication {
 	@Bean
 	public ModelMapper modelMapper() {
 		return new ModelMapper();
+	}
+
+	@Bean
+	public PasswordEncoder createPasswordEncoder() {
+		return new BCryptPasswordEncoder();
 	}
 }

--- a/src/main/java/com/urcodebin/api/dto/LoginDTO.java
+++ b/src/main/java/com/urcodebin/api/dto/LoginDTO.java
@@ -1,0 +1,28 @@
+package com.urcodebin.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LoginDTO {
+
+    @JsonProperty("username")
+    private String username;
+
+    @JsonProperty("password")
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/urcodebin/api/error/exception/InvalidLoginFormatException.java
+++ b/src/main/java/com/urcodebin/api/error/exception/InvalidLoginFormatException.java
@@ -1,0 +1,16 @@
+package com.urcodebin.api.error.exception;
+
+public class InvalidLoginFormatException extends RuntimeException {
+
+    public InvalidLoginFormatException() {
+        super("Invalid login format body. Please format your login body properly.");
+    }
+
+    public InvalidLoginFormatException(final String message, final Throwable throwable) {
+        super(message, throwable);
+    }
+
+    public InvalidLoginFormatException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/urcodebin/api/error/handler/ErrorResponse.java
+++ b/src/main/java/com/urcodebin/api/error/handler/ErrorResponse.java
@@ -1,9 +1,15 @@
 package com.urcodebin.api.error.handler;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
 import java.time.LocalDateTime;
 
 public class ErrorResponse {
 
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
     private LocalDateTime timestamp;
     private int status;
     private String error;

--- a/src/main/java/com/urcodebin/api/error/handler/ErrorResponse.java
+++ b/src/main/java/com/urcodebin/api/error/handler/ErrorResponse.java
@@ -15,6 +15,13 @@ public class ErrorResponse {
     private String error;
     private String message;
 
+    public ErrorResponse() {}
+
+    public ErrorResponse(Exception e) {
+        this.timestamp = LocalDateTime.now();
+        this.message = e.getMessage();
+    }
+
     public LocalDateTime getTimestamp() {
         return timestamp;
     }

--- a/src/main/java/com/urcodebin/api/error/handler/ResponseExceptionHandler.java
+++ b/src/main/java/com/urcodebin/api/error/handler/ResponseExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.urcodebin.api.error.handler;
 
-import com.urcodebin.api.error.exception.AccountInformationTakenException;
-import com.urcodebin.api.error.exception.MissingRequiredSourceCodeException;
-import com.urcodebin.api.error.exception.PasteNotFoundException;
-import com.urcodebin.api.error.exception.UserAccountNotFoundException;
+import com.urcodebin.api.error.exception.*;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/urcodebin/api/repository/UserAccountRepository.java
+++ b/src/main/java/com/urcodebin/api/repository/UserAccountRepository.java
@@ -3,9 +3,13 @@ package com.urcodebin.api.repository;
 import com.urcodebin.api.entities.UserAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
 
     boolean existsByEmail(String email);
 
     boolean existsByUsername(String username);
+
+    Optional<UserAccount> findByUsername(String username);
 }

--- a/src/main/java/com/urcodebin/api/security/ApplicationSecurityConfiguration.java
+++ b/src/main/java/com/urcodebin/api/security/ApplicationSecurityConfiguration.java
@@ -1,5 +1,6 @@
 package com.urcodebin.api.security;
 
+import com.urcodebin.api.security.filter.SecurityExceptionFilter;
 import com.urcodebin.api.security.filter.JWTAuthenticationFilter;
 import com.urcodebin.api.security.filter.JWTAuthorizationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -45,6 +47,7 @@ public class ApplicationSecurityConfiguration extends WebSecurityConfigurerAdapt
                 .antMatchers(HttpMethod.GET, PUBLIC_PASTE_URL).permitAll()
                 .anyRequest().authenticated()
                 .and()
+                .addFilterBefore(new SecurityExceptionFilter(), BasicAuthenticationFilter.class)
                 .addFilter(new JWTAuthenticationFilter(authenticationManager()))
                 .addFilter(new JWTAuthorizationFilter(authenticationManager()))
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);

--- a/src/main/java/com/urcodebin/api/security/ApplicationSecurityConfiguration.java
+++ b/src/main/java/com/urcodebin/api/security/ApplicationSecurityConfiguration.java
@@ -1,25 +1,58 @@
 package com.urcodebin.api.security;
 
+import com.urcodebin.api.security.filter.JWTAuthenticationFilter;
+import com.urcodebin.api.security.filter.JWTAuthorizationFilter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import static com.urcodebin.api.security.SecurityConstants.SIGN_UP_URL;
 
 @Configuration
 @EnableWebSecurity
 public class ApplicationSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
+    private final UserDetailsService userDetailsService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Autowired
+    public ApplicationSecurityConfiguration(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
+        this.userDetailsService = userDetailsService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder);
+    }
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable()
-                .authorizeRequests().anyRequest().permitAll();
+        http.cors().and().csrf().disable().authorizeRequests()
+                .antMatchers(HttpMethod.POST, SIGN_UP_URL).permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .addFilter(new JWTAuthenticationFilter(authenticationManager()))
+                .addFilter(new JWTAuthorizationFilter(authenticationManager()))
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
     }
 
     @Bean
-    public PasswordEncoder createPasswordEncoder() {
-        return new BCryptPasswordEncoder();
+    CorsConfigurationSource corsConfigurationSource() {
+        final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", new CorsConfiguration().applyPermitDefaultValues());
+        return source;
     }
 }

--- a/src/main/java/com/urcodebin/api/security/ApplicationSecurityConfiguration.java
+++ b/src/main/java/com/urcodebin/api/security/ApplicationSecurityConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -47,7 +47,7 @@ public class ApplicationSecurityConfiguration extends WebSecurityConfigurerAdapt
                 .antMatchers(HttpMethod.GET, PUBLIC_PASTE_URL).permitAll()
                 .anyRequest().authenticated()
                 .and()
-                .addFilterBefore(new SecurityExceptionFilter(), BasicAuthenticationFilter.class)
+                .addFilterBefore(new SecurityExceptionFilter(), LogoutFilter.class)
                 .addFilter(new JWTAuthenticationFilter(authenticationManager()))
                 .addFilter(new JWTAuthorizationFilter(authenticationManager()))
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);

--- a/src/main/java/com/urcodebin/api/security/ApplicationSecurityConfiguration.java
+++ b/src/main/java/com/urcodebin/api/security/ApplicationSecurityConfiguration.java
@@ -12,12 +12,12 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import static com.urcodebin.api.security.SecurityConstants.PUBLIC_PASTE_URL;
 import static com.urcodebin.api.security.SecurityConstants.SIGN_UP_URL;
 
 @Configuration
@@ -42,6 +42,7 @@ public class ApplicationSecurityConfiguration extends WebSecurityConfigurerAdapt
     protected void configure(HttpSecurity http) throws Exception {
         http.cors().and().csrf().disable().authorizeRequests()
                 .antMatchers(HttpMethod.POST, SIGN_UP_URL).permitAll()
+                .antMatchers(HttpMethod.GET, PUBLIC_PASTE_URL).permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilter(new JWTAuthenticationFilter(authenticationManager()))

--- a/src/main/java/com/urcodebin/api/security/SecurityConstants.java
+++ b/src/main/java/com/urcodebin/api/security/SecurityConstants.java
@@ -1,9 +1,15 @@
 package com.urcodebin.api.security;
 
+import javassist.NotFoundException;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;;
+import org.jasypt.properties.EncryptableProperties;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.Properties;
 
 public class SecurityConstants {
-
-    public static final String SECRET = "SECRET_KEY";
+    
     public static final long EXPIRATION_TIME = 7_200_000; // 2 Hours
     public static final String TOKEN_PREFIX = "Bearer ";
     public static final String HEADER_STRING = "Authorization";
@@ -11,4 +17,32 @@ public class SecurityConstants {
     public static final String LOGIN_URL = "/api/account/login";
     public static final String SIGN_UP_URL = "/api/account/signup";
     public static final String PUBLIC_PASTE_URL = "/api/paste/public";
+
+    public static String getSecret() {
+        StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
+        //We need the Jasypt password that is used to decrypt the SECRET property.
+        encryptor.setPassword(System.getenv("JASYPT_ENCRYPTOR_PASSWORD"));
+
+        InputStream inputStream;
+        try {
+            Properties prop = new EncryptableProperties(encryptor);
+            String propFileName = "application.properties";
+
+            inputStream = SecurityConstants.class.getClassLoader().getResourceAsStream(propFileName);
+            if (inputStream != null) {
+                prop.load(inputStream);
+            } else {
+                throw new FileNotFoundException("property file '" + propFileName + "' not found in the classpath");
+            }
+
+            String secret = prop.getProperty("SECRET");
+            if(secret == null){
+                throw new NotFoundException("SECRET property was not found in .properties file");
+            }
+            return secret;
+        } catch (Exception e) {
+            System.out.println("Exception: " + e.getMessage());
+            return null;
+        }
+    }
 }

--- a/src/main/java/com/urcodebin/api/security/SecurityConstants.java
+++ b/src/main/java/com/urcodebin/api/security/SecurityConstants.java
@@ -18,6 +18,14 @@ public class SecurityConstants {
     public static final String SIGN_UP_URL = "/api/account/signup";
     public static final String PUBLIC_PASTE_URL = "/api/paste/public";
 
+    /**
+     * The secret is not stored in plain text as it would raise security issues
+     * as it will be publicly available in the open-source project. To ensure
+     * security, the {@key SECRET} is encoded in a .properties file and is then
+     * decoded using Jasypt String Encryptor. This process requires a
+     * password which is safely stored as an environment variable called
+     * {@env JASYPT_ENCRYPTOR_PASSWORD}
+     */
     public static String getSecret() {
         StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
         //We need the Jasypt password that is used to decrypt the SECRET property.

--- a/src/main/java/com/urcodebin/api/security/SecurityConstants.java
+++ b/src/main/java/com/urcodebin/api/security/SecurityConstants.java
@@ -1,0 +1,11 @@
+package com.urcodebin.api.security;
+
+
+public class SecurityConstants {
+
+    public static final String SECRET = "SECRET_KEY";
+    public static final long EXPIRATION_TIME = 900_0000; // 15 mins
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String HEADER_STRING = "Authorization";
+    public static final String SIGN_UP_URL = "/api/account/signup";
+}

--- a/src/main/java/com/urcodebin/api/security/SecurityConstants.java
+++ b/src/main/java/com/urcodebin/api/security/SecurityConstants.java
@@ -4,8 +4,11 @@ package com.urcodebin.api.security;
 public class SecurityConstants {
 
     public static final String SECRET = "SECRET_KEY";
-    public static final long EXPIRATION_TIME = 900_0000; // 15 mins
+    public static final long EXPIRATION_TIME = 7_200_000; // 2 Hours
     public static final String TOKEN_PREFIX = "Bearer ";
     public static final String HEADER_STRING = "Authorization";
+
+    public static final String LOGIN_URL = "/api/account/login";
     public static final String SIGN_UP_URL = "/api/account/signup";
+    public static final String PUBLIC_PASTE_URL = "/api/paste/public";
 }

--- a/src/main/java/com/urcodebin/api/security/SecurityConstants.java
+++ b/src/main/java/com/urcodebin/api/security/SecurityConstants.java
@@ -5,7 +5,6 @@ import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jasypt.properties.EncryptableProperties;
 
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 

--- a/src/main/java/com/urcodebin/api/security/SecurityConstants.java
+++ b/src/main/java/com/urcodebin/api/security/SecurityConstants.java
@@ -1,10 +1,11 @@
 package com.urcodebin.api.security;
 
 import javassist.NotFoundException;
-import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jasypt.properties.EncryptableProperties;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
@@ -49,8 +50,7 @@ public class SecurityConstants {
             }
             return secret;
         } catch (Exception e) {
-            System.out.println("Exception: " + e.getMessage());
-            return null;
+            throw new RuntimeException(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/urcodebin/api/security/filter/JWTAuthenticationFilter.java
+++ b/src/main/java/com/urcodebin/api/security/filter/JWTAuthenticationFilter.java
@@ -28,6 +28,7 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     public JWTAuthenticationFilter(AuthenticationManager authenticationManager) {
         this.authenticationManager = authenticationManager;
 
+        //Sets the custom LOGIN url instead of using the default /login url
         setFilterProcessesUrl(LOGIN_URL);
     }
 
@@ -35,13 +36,13 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     public Authentication attemptAuthentication(HttpServletRequest request,
                                                 HttpServletResponse response) throws AuthenticationException {
         try {
-            LoginDTO cred = new ObjectMapper()
+            LoginDTO credentials = new ObjectMapper()
                     .readValue(request.getInputStream(), LoginDTO.class);
 
             return authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(
-                            cred.getUsername(),
-                            cred.getPassword(),
+                            credentials.getUsername(),
+                            credentials.getPassword(),
                             new ArrayList<>())
             );
         } catch (IOException e) {
@@ -54,11 +55,11 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                                             HttpServletResponse response,
                                             FilterChain chain,
                                             Authentication auth) throws IOException, ServletException {
-        String token = JWT.create()
+        String createdToken = JWT.create()
                 .withSubject(((User) auth.getPrincipal()).getUsername())
                 .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
                 .sign(Algorithm.HMAC512(getSecret().getBytes()));
 
-        response.addHeader(HEADER_STRING, TOKEN_PREFIX + token);
+        response.addHeader(HEADER_STRING, TOKEN_PREFIX + createdToken);
     }
 }

--- a/src/main/java/com/urcodebin/api/security/filter/JWTAuthenticationFilter.java
+++ b/src/main/java/com/urcodebin/api/security/filter/JWTAuthenticationFilter.java
@@ -57,7 +57,7 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String token = JWT.create()
                 .withSubject(((User) auth.getPrincipal()).getUsername())
                 .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
-                .sign(Algorithm.HMAC512(SECRET.getBytes()));
+                .sign(Algorithm.HMAC512(getSecret().getBytes()));
 
         response.addHeader(HEADER_STRING, TOKEN_PREFIX + token);
     }

--- a/src/main/java/com/urcodebin/api/security/filter/JWTAuthenticationFilter.java
+++ b/src/main/java/com/urcodebin/api/security/filter/JWTAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.urcodebin.api.security.filter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.urcodebin.api.dto.LoginDTO;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+
+import static com.urcodebin.api.security.SecurityConstants.*;
+
+public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+
+    public JWTAuthenticationFilter(AuthenticationManager authenticationManager) {
+        this.authenticationManager = authenticationManager;
+
+        setFilterProcessesUrl("/api/account/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+                                                HttpServletResponse response) throws AuthenticationException {
+        try {
+            LoginDTO cred = new ObjectMapper()
+                    .readValue(request.getInputStream(), LoginDTO.class);
+
+            return authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            cred.getUsername(),
+                            cred.getPassword(),
+                            new ArrayList<>())
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+                                            HttpServletResponse response,
+                                            FilterChain chain,
+                                            Authentication auth) throws IOException, ServletException {
+        String token = JWT.create()
+                .withSubject(((User) auth.getPrincipal()).getUsername())
+                .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .sign(Algorithm.HMAC512(SECRET.getBytes()));
+
+        response.addHeader(HEADER_STRING, TOKEN_PREFIX + token);
+    }
+}

--- a/src/main/java/com/urcodebin/api/security/filter/JWTAuthenticationFilter.java
+++ b/src/main/java/com/urcodebin/api/security/filter/JWTAuthenticationFilter.java
@@ -28,7 +28,7 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     public JWTAuthenticationFilter(AuthenticationManager authenticationManager) {
         this.authenticationManager = authenticationManager;
 
-        setFilterProcessesUrl("/api/account/login");
+        setFilterProcessesUrl(LOGIN_URL);
     }
 
     @Override

--- a/src/main/java/com/urcodebin/api/security/filter/JWTAuthorizationFilter.java
+++ b/src/main/java/com/urcodebin/api/security/filter/JWTAuthorizationFilter.java
@@ -1,0 +1,58 @@
+package com.urcodebin.api.security.filter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static com.urcodebin.api.security.SecurityConstants.*;
+
+public class JWTAuthorizationFilter extends BasicAuthenticationFilter {
+
+    public JWTAuthorizationFilter(AuthenticationManager authManager) {
+        super(authManager);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws IOException, ServletException {
+        String header = request.getHeader(HEADER_STRING);
+
+        if(header == null || !header.startsWith(TOKEN_PREFIX)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        UsernamePasswordAuthenticationToken authentication = getAuthentication(request);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        chain.doFilter(request, response);
+    }
+
+    private UsernamePasswordAuthenticationToken getAuthentication(HttpServletRequest request) {
+        String token = request.getHeader(HEADER_STRING);
+
+        if(token == null) return null;
+
+        String user = JWT.require(Algorithm.HMAC512(SECRET.getBytes()))
+                .build()
+                .verify(token.replace(TOKEN_PREFIX, ""))
+                .getSubject();
+
+        if(user == null)
+            return null;
+        else
+            return new UsernamePasswordAuthenticationToken(user, null, new ArrayList<>());
+
+    }
+}

--- a/src/main/java/com/urcodebin/api/security/filter/JWTAuthorizationFilter.java
+++ b/src/main/java/com/urcodebin/api/security/filter/JWTAuthorizationFilter.java
@@ -44,7 +44,7 @@ public class JWTAuthorizationFilter extends BasicAuthenticationFilter {
 
         if(token == null) return null;
 
-        String user = JWT.require(Algorithm.HMAC512(SECRET.getBytes()))
+        String user = JWT.require(Algorithm.HMAC512(getSecret().getBytes()))
                 .build()
                 .verify(token.replace(TOKEN_PREFIX, ""))
                 .getSubject();

--- a/src/main/java/com/urcodebin/api/security/filter/SecurityExceptionFilter.java
+++ b/src/main/java/com/urcodebin/api/security/filter/SecurityExceptionFilter.java
@@ -2,6 +2,7 @@ package com.urcodebin.api.security.filter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.urcodebin.api.error.exception.InvalidLoginFormatException;
 import com.urcodebin.api.error.handler.ErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +14,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.LocalDateTime;
 
 public class SecurityExceptionFilter extends OncePerRequestFilter {
 
@@ -27,10 +27,8 @@ public class SecurityExceptionFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (RuntimeException e) {
             LOGGER.error("Security Filter Error Occurred: {}", e.getMessage());
-            ErrorResponse errorResponse = new ErrorResponse();
-            errorResponse.setTimestamp(LocalDateTime.now());
+            ErrorResponse errorResponse = new ErrorResponse(e);
             errorResponse.setError(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
-            errorResponse.setMessage(e.getMessage());
             errorResponse.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
 
             response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());

--- a/src/main/java/com/urcodebin/api/security/filter/SecurityExceptionFilter.java
+++ b/src/main/java/com/urcodebin/api/security/filter/SecurityExceptionFilter.java
@@ -1,0 +1,48 @@
+package com.urcodebin.api.security.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.urcodebin.api.error.handler.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+public class SecurityExceptionFilter extends OncePerRequestFilter {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (RuntimeException e) {
+            LOGGER.error("Security Filter Error Occurred: {}", e.getMessage());
+            ErrorResponse errorResponse = new ErrorResponse();
+            errorResponse.setTimestamp(LocalDateTime.now());
+            errorResponse.setError(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
+            errorResponse.setMessage(e.getMessage());
+            errorResponse.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+
+            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+            response.getWriter().write(convertObjectToJson(errorResponse));
+        }
+    }
+
+    public String convertObjectToJson(Object object) throws JsonProcessingException {
+        if (object == null) {
+            return null;
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(object);
+    }
+}

--- a/src/main/java/com/urcodebin/api/security/handler/FailedAuthenticationHandler.java
+++ b/src/main/java/com/urcodebin/api/security/handler/FailedAuthenticationHandler.java
@@ -1,0 +1,46 @@
+package com.urcodebin.api.security.handler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.urcodebin.api.error.handler.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedCredentialsNotFoundException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class FailedAuthenticationHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException e) throws IOException, ServletException {
+
+        ErrorResponse errorResponse = new ErrorResponse(e);
+        if(e instanceof PreAuthenticatedCredentialsNotFoundException) {
+            updateErrorResponse(errorResponse, HttpStatus.BAD_REQUEST);
+        } else {
+            updateErrorResponse(errorResponse, HttpStatus.UNAUTHORIZED);
+        }
+
+        response.setStatus(errorResponse.getStatus());
+        response.getWriter().write(convertObjectToJson(errorResponse));
+    }
+
+    private void updateErrorResponse(ErrorResponse error, HttpStatus status) {
+        error.setStatus(status.value());
+        error.setError(status.getReasonPhrase());
+    }
+
+    private String convertObjectToJson(Object object) throws JsonProcessingException {
+        if (object == null) {
+            return null;
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(object);
+    }
+}

--- a/src/main/java/com/urcodebin/api/services/UserAccountServiceImpl.java
+++ b/src/main/java/com/urcodebin/api/services/UserAccountServiceImpl.java
@@ -29,8 +29,13 @@ public class UserAccountServiceImpl implements UserAccountService {
     @Override
     public Optional<UserAccount> getUserAccountById(Long accountId) {
         LOGGER.info("Finding UserAccount with ID: {}", accountId);
-        final Optional<UserAccount> foundAccount = userAccountRepository.findById(accountId);
-        return foundAccount.or(Optional::empty);
+        return userAccountRepository.findById(accountId);
+    }
+
+    @Override
+    public Optional<UserAccount> findByUsername(String username) {
+        LOGGER.info("Finding UserAccount with Username: {}", username);
+        return userAccountRepository.findByUsername(username);
     }
 
     @Override

--- a/src/main/java/com/urcodebin/api/services/UserDetailsServiceImpl.java
+++ b/src/main/java/com/urcodebin/api/services/UserDetailsServiceImpl.java
@@ -1,0 +1,34 @@
+package com.urcodebin.api.services;
+
+import com.urcodebin.api.entities.UserAccount;
+import com.urcodebin.api.services.interfaces.UserAccountService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserAccountService userAccountService;
+
+    @Autowired
+    public UserDetailsServiceImpl(UserAccountService userAccountService) {
+        this.userAccountService = userAccountService;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<UserAccount> foundAccount = userAccountService.findByUsername(username);
+        if(foundAccount.isEmpty()) {
+            throw new UsernameNotFoundException(username);
+        }
+        final UserAccount account = foundAccount.get();
+        return new User(account.getUsername(), account.getPassword(), new ArrayList<>());
+    }
+}

--- a/src/main/java/com/urcodebin/api/services/interfaces/UserAccountService.java
+++ b/src/main/java/com/urcodebin/api/services/interfaces/UserAccountService.java
@@ -9,6 +9,8 @@ public interface UserAccountService {
 
     Optional<UserAccount> getUserAccountById(Long accountId);
 
+    Optional<UserAccount> findByUsername(String username);
+
     UserAccount signupNewUserAccount(SignupRequestBody signupAccount);
 
     boolean isAccountEmailTaken(String email);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,5 @@ spring.jpa.hibernate.ddl-auto=none
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/ur_code_paste
 spring.datasource.username=root
 spring.datasource.password=password
+
+SECRET=ENC(iJCjtiy3h9RUb2loDdsxMddubUEu79pW)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,4 +7,5 @@ spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/ur_code_paste
 spring.datasource.username=root
 spring.datasource.password=password
 
+logging.level.org.springframework.security.web.FilterChainProxy=DEBUG
 SECRET=ENC(iJCjtiy3h9RUb2loDdsxMddubUEu79pW)


### PR DESCRIPTION
This is a large change to the security of the entire application. All endpoints now require a JWT token except for two main endpoints
**Publicly Available:**
 - _/api/account/signup_ [POST signup user endpoint]
 - _/api/paste/public_ [GET a publicly available CodePaste]
 
 All other endpoints require an authorization JWT token that is now being provided through a login endpoint.
 **Get Token Login:** _/api/account/login_ [POST login endpoint to get JWT token]
 
 JWT Key encryption is using HMAC512 and the SECRET Key for encryption is decrypted using Jasypt to ensure the secret key is not publicly available in the source code.